### PR TITLE
master + works > cpus

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -61,7 +61,7 @@ class Master {
     const workers = this.options.workers;
     let index = 0;
     const promises = [];
-    while (index++ < workers) {
+    while (index++ < workers - 1) {
       const env = Object.assign({}, this.getForkEnv());
       const promise = util.forkWorker(env);
       promises.push(promise);


### PR DESCRIPTION
master + works 线程大于 cpu 核心数 导致进程切换在高并发下 浪费了大量资源

更改之前的测试结果
![image](https://user-images.githubusercontent.com/6869168/48468159-1136b780-e826-11e8-9589-c5f3afad32fc.png)

更改之后的测试结果
![image](https://user-images.githubusercontent.com/6869168/48468193-26134b00-e826-11e8-83cc-18c18d55061a.png)
本地测试 说服性较小 但是理论基础在