### PR TITLE
fix get workers by target type one

### DIFF
--- a/lib/messenger.js
+++ b/lib/messenger.js
@@ -28,7 +28,8 @@ class Messenger extends events {
     const aliveWorkers = util.getAliveWorkers();
     if (type === 'all') return aliveWorkers;
     if (type === 'one') {
-      if (!aliveWorkers.length || aliveWorkers[0] !== cWorker) return [];
+      if (!aliveWorkers.length) return [];
+      if (aliveWorkers.find(w => w === cWorker)) return [cWorker];
       return [aliveWorkers[0]];
     }
   }


### PR DESCRIPTION
进程间消息通信时，开启多workers发现消息不能被消费。测试发现时获取一个处于alive状态的进行发送消息的工程中，原代码只是检测是否与aliveWorkers[0]相同，实际上触发发送消息的worker可以是任意一个。

所以改为检查当前worker是否是alive即可，如果不可用则返回可用中的第一个。其实也可以直接返回aliveWorkers[0]的。